### PR TITLE
Обновление версии зависимости

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "require": {
-    "yandex-market/yandex-market-php-common": "1.0.0"
+    "yandex-market/yandex-market-php-common": "1.*"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "require": {
-    "yandex-market/yandex-market-php-common": "1.*"
+    "yandex-market/yandex-market-php-common": "1.1.*"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",


### PR DESCRIPTION
https://github.com/yandex-market/beru-php-partner требует yandex-market-php-common версии "1.1.0", что порождает конфиликт версии при установке через composer, и не дает использовать yandex-market-php-oauth совместно с beru-php-partner